### PR TITLE
Avoid leaking arguments

### DIFF
--- a/src/api/balloon.js
+++ b/src/api/balloon.js
@@ -383,7 +383,7 @@ Tooltip.prototype.position = function (x, y) {
         x = this._p[0];
         y = this._p[1];
     } else {
-        this._p = arguments;
+        this._p = [x, y];
     }
     var target = typeof x === 'number' ? {
         left: 0 | x,


### PR DESCRIPTION
Passing `arguments` out of function scope may prevent optimization in Chrome: https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments