### PR TITLE
Fix for wrong timezones on the test

### DIFF
--- a/test/element-interval.test.js
+++ b/test/element-interval.test.js
@@ -680,9 +680,9 @@ define(function (require) {
         }
     );
 
-    var offsetHrs = new Date().getTimezoneOffset() / 60;
-    var offsetISO = '0' + Math.abs(offsetHrs) + ':00';
     var iso = function (str) {
+        var offsetHrs = new Date(str).getTimezoneOffset() / 60;
+        var offsetISO = '0' + Math.abs(offsetHrs) + ':00';
         return (str + '+' + offsetISO);
     };
 

--- a/test/formatter-registry.test.js
+++ b/test/formatter-registry.test.js
@@ -4,9 +4,9 @@ define(function (require) {
     var tauChart = require('src/tau.charts');
     describe("Formatter registry", function () {
 
-        var offsetHrs = new Date().getTimezoneOffset() / 60;
-        var offsetISO = '0' + Math.abs(offsetHrs) + ':00';
         var iso = function (str) {
+            var offsetHrs = new Date(str).getTimezoneOffset() / 60;
+            var offsetISO = '0' + Math.abs(offsetHrs) + ':00';
             return (str + '+' + offsetISO);
         };
 

--- a/test/tooltip-plugin.test.js
+++ b/test/tooltip-plugin.test.js
@@ -9,9 +9,9 @@ var tauCharts = require('tauCharts');
 var tooltip = require('plugins/tooltip');
 var describeChart = testUtils.describeChart;
 
-var offsetHrs = new Date().getTimezoneOffset() / 60;
-var offsetISO = '0' + Math.abs(offsetHrs) + ':00';
 var iso = function (str) {
+    var offsetHrs = new Date(str).getTimezoneOffset() / 60;
+    var offsetISO = '0' + Math.abs(offsetHrs) + ':00';
     return (str + '+' + offsetISO);
 };
 

--- a/test/unit-domain-mixin.test.js
+++ b/test/unit-domain-mixin.test.js
@@ -9,9 +9,9 @@ define(function (require) {
     describe("Unit domain decorator", function () {
 
         var decorator;
-        var offsetHrs = new Date().getTimezoneOffset() / 60;
-        var offsetISO = '0' + Math.abs(offsetHrs) + ':00';
         var iso = function (str) {
+            var offsetHrs = new Date(str).getTimezoneOffset() / 60;
+            var offsetISO = '0' + Math.abs(offsetHrs) + ':00';
             return (str + '+' + offsetISO);
         };
 

--- a/test/unit-domain-period-generator.test.js
+++ b/test/unit-domain-period-generator.test.js
@@ -3,9 +3,9 @@ define(function (require) {
     var tauChart = require('src/tau.charts');
     describe("Unit domain period generator", function () {
 
-        var offsetHrs = new Date().getTimezoneOffset() / 60;
-        var offsetISO = '0' + Math.abs(offsetHrs) + ':00';
         var iso = function (str) {
+            var offsetHrs = new Date(str).getTimezoneOffset() / 60;
+            var offsetISO = '0' + Math.abs(offsetHrs) + ':00';
             return (str + '+' + offsetISO);
         };
         var PeriodGenerator;


### PR DESCRIPTION
The bug was because the time offset is different for the summer time (the offset might be +120 in February and +180 in July) so the offset needs to be calculated for each date