### PR TITLE
Use lowercase package name for cjs and amd

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "tauCharts",
+  "name": "taucharts",
   "version": "0.10.0-beta.7",
   "homepage": "https://github.com/TargetProcess/tauCharts",
   "description": "D3 based data-focused charting library",

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -137,7 +137,7 @@ var exportBuild = {
 var webpackConf = {
     entry: './src/tau.charts.js',
     output: {
-        library: 'taucharts',
+        library: 'tauCharts',
         libraryTarget: 'umd',
         path: 'build/development',
         filename: 'tauCharts.js'

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -42,6 +42,7 @@ var generateTestConf = function (addLoaders) {
                 testUtils: 'test/utils/utils.js',
                 brewer: 'src/addons/color-brewer.js',
                 tauCharts: 'src/tau.charts.js',
+                taucharts: 'src/tau.charts.js',
                 'print.style.css': 'plugins/print.style.css',
                 rgbcolor: 'bower_components/canvg/rgbcolor.js',
                 stackblur: 'bower_components/canvg/StackBlur.js',
@@ -102,6 +103,7 @@ var exportBuild = {
     resolve: {
         alias: {
             tauCharts: toAbsolute('../src/tau.charts.js'),
+            taucharts: toAbsolute('../src/tau.charts.js'),
             'print.style.css': toAbsolute('../plugins/print.style.css'),
             rgbcolor: toAbsolute('../bower_components/canvg/rgbcolor.js'),
             stackblur: toAbsolute('../bower_components/canvg/StackBlur.js'),
@@ -112,7 +114,7 @@ var exportBuild = {
         }
     },
     externals: {
-        tauCharts: 'tauCharts'
+        taucharts: 'taucharts'
     },
     module: {
         loaders: [
@@ -135,7 +137,7 @@ var exportBuild = {
 var webpackConf = {
     entry: './src/tau.charts.js',
     output: {
-        library: 'tauCharts',
+        library: 'taucharts',
         libraryTarget: 'umd',
         path: 'build/development',
         filename: 'tauCharts.js'

--- a/examples/dev-quick-test/ex-055.js
+++ b/examples/dev-quick-test/ex-055.js
@@ -1,10 +1,10 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['tauCharts'], function (tauPlugins) {
+        define(['taucharts'], function (tauPlugins) {
             return factory(tauPlugins);
         });
     } else if (typeof module === 'object' && module.exports) {
-        var tauPlugins = require('tauCharts');
+        var tauPlugins = require('taucharts');
         module.exports = factory(tauPlugins);
     } else {
         factory(this.tauCharts);

--- a/plugins/annotations.js
+++ b/plugins/annotations.js
@@ -1,10 +1,10 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['tauCharts'], function (tauPlugins) {
+        define(['taucharts'], function (tauPlugins) {
             return factory(tauPlugins);
         });
     } else if (typeof module === 'object' && module.exports) {
-        var tauPlugins = require('tauCharts');
+        var tauPlugins = require('taucharts');
         module.exports = factory(tauPlugins);
     } else {
         factory(this.tauCharts);

--- a/plugins/box-whiskers.js
+++ b/plugins/box-whiskers.js
@@ -1,10 +1,10 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['tauCharts'], function (tauPlugins) {
+        define(['taucharts'], function (tauPlugins) {
             return factory(tauPlugins);
         });
     } else if (typeof module === 'object' && module.exports) {
-        var tauPlugins = require('tauCharts');
+        var tauPlugins = require('taucharts');
         module.exports = factory(tauPlugins);
     } else {
         factory(this.tauCharts);

--- a/plugins/export.js
+++ b/plugins/export.js
@@ -1,6 +1,6 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['tauCharts', 'canvg', 'FileSaver', 'promise', 'print.style.css', 'fetch'],
+        define(['taucharts', 'canvg', 'FileSaver', 'promise', 'print.style.css', 'fetch'],
             function (tauPlugins, canvg, saveAs, Promise, printCss) {
                 window.Promise = window.Promise || Promise.Promise;
                 return factory(tauPlugins, canvg, saveAs, window.Promise, printCss);

--- a/plugins/floating-axes.js
+++ b/plugins/floating-axes.js
@@ -1,10 +1,10 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['tauCharts'], function (tauPlugins) {
+        define(['taucharts'], function (tauPlugins) {
             return factory(tauPlugins);
         });
     } else if (typeof module === 'object' && module.exports) {
-        var tauPlugins = require('tauCharts');
+        var tauPlugins = require('taucharts');
         module.exports = factory(tauPlugins);
     } else {
         factory(this.tauCharts);

--- a/plugins/geomap-legend.js
+++ b/plugins/geomap-legend.js
@@ -1,10 +1,10 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['tauCharts'], function (tauPlugins) {
+        define(['taucharts'], function (tauPlugins) {
             return factory(tauPlugins);
         });
     } else if (typeof module === 'object' && module.exports) {
-        var tauPlugins = require('tauCharts');
+        var tauPlugins = require('taucharts');
         module.exports = factory(tauPlugins);
     } else {
         factory(this.tauCharts);

--- a/plugins/geomap-tooltip.js
+++ b/plugins/geomap-tooltip.js
@@ -1,10 +1,10 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['tauCharts'], function (tauPlugins) {
+        define(['taucharts'], function (tauPlugins) {
             return factory(tauPlugins);
         });
     } else if (typeof module === 'object' && module.exports) {
-        var tauPlugins = require('tauCharts');
+        var tauPlugins = require('taucharts');
         module.exports = factory(tauPlugins);
     } else {
         factory(this.tauCharts);

--- a/plugins/layers.js
+++ b/plugins/layers.js
@@ -1,11 +1,11 @@
 // jscs:disable *
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['tauCharts'], function (tauPlugins) {
+        define(['taucharts'], function (tauPlugins) {
             return factory(tauPlugins);
         });
     } else if (typeof module === 'object' && module.exports) {
-        var tauPlugins = require('tauCharts');
+        var tauPlugins = require('taucharts');
         module.exports = factory(tauPlugins);
     } else {
         factory(this.tauCharts);

--- a/plugins/legend.js
+++ b/plugins/legend.js
@@ -1,10 +1,10 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['tauCharts'], function (tauPlugins) {
+        define(['taucharts'], function (tauPlugins) {
             return factory(tauPlugins);
         });
     } else if (typeof module === 'object' && module.exports) {
-        var tauPlugins = require('tauCharts');
+        var tauPlugins = require('taucharts');
         module.exports = factory(tauPlugins);
     } else {
         factory(this.tauCharts);

--- a/plugins/parallel-brushing.js
+++ b/plugins/parallel-brushing.js
@@ -1,10 +1,10 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['tauCharts'], function (tauPlugins) {
+        define(['taucharts'], function (tauPlugins) {
             return factory(tauPlugins);
         });
     } else if (typeof module === 'object' && module.exports) {
-        var tauPlugins = require('tauCharts');
+        var tauPlugins = require('taucharts');
         module.exports = factory(tauPlugins);
     } else {
         factory(this.tauCharts);

--- a/plugins/parallel-tooltip.js
+++ b/plugins/parallel-tooltip.js
@@ -1,10 +1,10 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['tauCharts'], function (tauPlugins) {
+        define(['taucharts'], function (tauPlugins) {
             return factory(tauPlugins);
         });
     } else if (typeof module === 'object' && module.exports) {
-        var tauPlugins = require('tauCharts');
+        var tauPlugins = require('taucharts');
         module.exports = factory(tauPlugins);
     } else {
         factory(this.tauCharts);

--- a/plugins/quick-filter.js
+++ b/plugins/quick-filter.js
@@ -1,10 +1,10 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['tauCharts'], function (tauPlugins) {
+        define(['taucharts'], function (tauPlugins) {
             return factory(tauPlugins);
         });
     } else if (typeof module === 'object' && module.exports) {
-        var tauPlugins = require('tauCharts');
+        var tauPlugins = require('taucharts');
         module.exports = factory(tauPlugins);
     } else {
         factory(this.tauCharts);

--- a/plugins/settings.js
+++ b/plugins/settings.js
@@ -1,10 +1,10 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['tauCharts'], function (tauPlugins) {
+        define(['taucharts'], function (tauPlugins) {
             return factory(tauPlugins);
         });
     } else if (typeof module === 'object' && module.exports) {
-        var tauPlugins = require('tauCharts');
+        var tauPlugins = require('taucharts');
         module.exports = factory(tauPlugins);
     } else {
         factory(this.tauCharts);

--- a/plugins/tooltip.js
+++ b/plugins/tooltip.js
@@ -1,10 +1,10 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['tauCharts'], function (tauPlugins) {
+        define(['taucharts'], function (tauPlugins) {
             return factory(tauPlugins);
         });
     } else if (typeof module === 'object' && module.exports) {
-        var tauPlugins = require('tauCharts');
+        var tauPlugins = require('taucharts');
         module.exports = factory(tauPlugins);
     } else {
         factory(this.tauCharts);

--- a/plugins/trendline.js
+++ b/plugins/trendline.js
@@ -1,10 +1,10 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['tauCharts'], function (tauPlugins) {
+        define(['taucharts'], function (tauPlugins) {
             return factory(tauPlugins);
         });
     } else if (typeof module === 'object' && module.exports) {
-        var tauPlugins = require('tauCharts');
+        var tauPlugins = require('taucharts');
         module.exports = factory(tauPlugins);
     } else {
         factory(this.tauCharts);

--- a/src/addons/color-brewer.js
+++ b/src/addons/color-brewer.js
@@ -1,10 +1,10 @@
 (function (definition) {
     if (typeof define === "function" && define.amd) {
-        define(['tauCharts'], function (tauCharts) {
+        define(['taucharts'], function (tauCharts) {
             return definition(tauCharts);
         });
     } else if (typeof module === "object" && module.exports) {
-        var tauCharts = require('tauCharts');
+        var tauCharts = require('taucharts');
         module.exports = definition(tauCharts);
     } else {
         definition(this.tauCharts);

--- a/test/tooltip-plugin.test.js
+++ b/test/tooltip-plugin.test.js
@@ -5,7 +5,7 @@ var $ = require('jquery');
 var expect = require('chai').expect;
 var testUtils = require('testUtils');
 var stubTimeout = testUtils.stubTimeout;
-var tauCharts = require('tauCharts');
+var tauCharts = require('taucharts');
 var tooltip = require('plugins/tooltip');
 var describeChart = testUtils.describeChart;
 


### PR DESCRIPTION
CJS module names should always be in lowercase.

Using `require('tauChart')` and `define(['tauChart'], ...)` (camelCase) with `'tauchart'` (lower case) name in `package.json` breaks using this package with some bundlers like webpack