### PR TITLE
Fixed wrong tooltip position for scrolled body

### DIFF
--- a/less/plugins/tooltip.less
+++ b/less/plugins/tooltip.less
@@ -2,7 +2,6 @@
 
 .graphical-report {
     &__tooltip {
-        pointer-events: none;
         position: absolute;
         top: 0;
         left: 0;
@@ -32,10 +31,6 @@
             overflow: hidden;
             padding: 15px 15px 10px 15px;
             box-sizing: border-box;
-        }
-
-        &.stuck {
-            pointer-events: initial;
         }
 
         &.stuck &__exclude,

--- a/plugins/tooltip.js
+++ b/plugins/tooltip.js
@@ -249,20 +249,28 @@
                     .forEach(function (node) {
 
                         node.on('data-hover', function (sender, e) {
+                            var bodyRect = document.body.getBoundingClientRect();
                             this.setState({
                                 highlight: (e.data ? {
                                     data: e.data,
-                                    cursor: {x: e.event.clientX, y: e.event.clientY},
+                                    cursor: {
+                                        x: (e.event.clientX - bodyRect.left),
+                                        y: (e.event.clientY - bodyRect.top)
+                                    },
                                     unit: sender
                                 } : null)
                             });
                         }.bind(this));
 
                         node.on('data-click', function (sender, e) {
+                            var bodyRect = document.body.getBoundingClientRect();
                             this.setState(e.data ? {
                                 highlight: {
                                     data: e.data,
-                                    cursor: {x: e.event.clientX, y: e.event.clientY},
+                                    cursor: {
+                                        x: (e.event.clientX - bodyRect.left),
+                                        y: (e.event.clientY - bodyRect.top)
+                                    },
                                     unit: sender
                                 },
                                 isStuck: true


### PR DESCRIPTION
- Consider body rectangle when calculating tooltip position.
- Stop disabling pointer events for tooltip.