### PR TITLE
Fix width of .graphical-report__progress to not exceed parent div

### DIFF
--- a/less/layout.less
+++ b/less/layout.less
@@ -23,6 +23,7 @@
 
         &__header {
             .flex(@flex-shrink:0.1);
+            position: relative;
         }
 
         &__container {
@@ -109,7 +110,3 @@
         }
     }
 }
-
-
-
-


### PR DESCRIPTION
Add the CSS rule, "position: relative", to the parent's div in order to
limit the .graphical-report__progress div's width, which is "position:
absolute".

Fixes #353