### PR TITLE
Fixed Crosshair plugin in FireFox

### DIFF
--- a/less/plugins/crosshair.less
+++ b/less/plugins/crosshair.less
@@ -28,6 +28,7 @@
     &__label__text-shadow {
         stroke-linejoin: round;
         stroke-width: 3px;
+        visibility: hidden;
     }
 
     &__label__box {

--- a/plugins/crosshair.js
+++ b/plugins/crosshair.js
@@ -84,6 +84,8 @@
 
             g.select('.tau-crosshair__label__box')
                 .attr('fill', color)
+                .attr('rx', options.boxCornerRadius)
+                .attr('ry', options.boxCornerRadius)
                 .attr('x', x + boxDx)
                 .attr('y', y + boxDy)
                 .attr('width', boxWidth)
@@ -115,8 +117,8 @@
             },
 
             show: function (args) {
-                setValues(args);
                 options.container.appendChild(node);
+                setValues(args);
                 fixOverflow();
                 return instance;
             },
@@ -142,6 +144,7 @@
                 formatters: {},
                 labelBoxHPadding: 5,
                 labelBoxVPadding: 3,
+                labelBoxCornerRadius: 3,
                 axisHPadding: 22,
                 axisVPadding: 22
             });
@@ -173,6 +176,7 @@
                         chart: this._chart,
                         halign: dir === 'x' ? 'middle' : 'left',
                         valign: dir === 'x' ? 'bottom' : 'middle',
+                        boxCornerRadius: settings.labelBoxCornerRadius,
                         hpad: settings.labelBoxHPadding,
                         vpad: settings.labelBoxVPadding
                     });


### PR DESCRIPTION
- Fixed getting bounding box in FireFox.
- Use attributes for corner radius.
- Hide text shadow.