### PR TITLE
Build both minified and unminified files for production

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,7 @@ module.exports = function (grunt) {
                     'build/development/tauCharts.color-brewer.js',
                     'build/development/plugins/*.js'
                 ],
-                dest: 'build/production/tauCharts.min.js'
+                dest: 'build/production/tauCharts.js'
             },
             prodCSS: {
                 files: cssConfig.prodCss

--- a/bower.json
+++ b/bower.json
@@ -8,8 +8,8 @@
     "charts"
   ],
   "main": [
-    "build/production/tauCharts.min.js",
-    "build/production/tauCharts.min.css"
+    "build/production/tauCharts.js",
+    "build/production/tauCharts.css"
   ],
   "license": "Apache License 2.0",
   "private": false,

--- a/config/css.config.js
+++ b/config/css.config.js
@@ -58,23 +58,31 @@ var generateThemes = function () {
         prodCss: [null].concat(themes).reduce(
             function (memo, key) {
                 var suffix = generateCompatibleSuffixes(key);
-                memo['build/production/tauCharts' + suffix.dst + '.min.css'] = ['build/development/**/*' + suffix.src + '.css'];
-                return memo;
-            },
-            {}),
-
-        cssMin: [null].concat(themes).reduce(
-            function (memo, key) {
-                var suffix = generateCompatibleSuffixes(key);
                 memo.push({
-                    src: 'build/production/tauCharts' + suffix.dst + '.min.css',
-                    dest: 'build/production/tauCharts' + suffix.dst + '.min.css'
+                    src: 'build/development/**/*' + suffix.src + '.css',
+                    dest: 'build/production/tauCharts' + suffix.dst + '.css'
                 });
                 return memo;
             },
             [
                 {
                     src: 'css/base.css',
+                    dest: 'build/production/tauCharts.normalize.css'
+                }
+            ]),
+
+        cssMin: [null].concat(themes).reduce(
+            function (memo, key) {
+                var suffix = generateCompatibleSuffixes(key);
+                memo.push({
+                    src: 'build/production/tauCharts' + suffix.dst + '.css',
+                    dest: 'build/production/tauCharts' + suffix.dst + '.min.css'
+                });
+                return memo;
+            },
+            [
+                {
+                    src: 'build/production/tauCharts.normalize.css',
                     dest: 'build/production/tauCharts.normalize.min.css'
                 }
             ])


### PR DESCRIPTION
In bower.json, use the unminified production files to avoid Bower
warning:

invalid-meta The "main" field cannot contain minified files

Fixes #383