### PR TITLE
Fix JS and CSS minification

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,7 @@ const banner = () => {
     const year = now.getUTCFullYear();
     return [
         `/*`,
-        `${package.name} v${package.version} (${today})`,
+        `${package.name}@${package.version} (${today})`,
         `Copyright ${year} ${package.author.name}`,
         `Licensed under ${package.licenses.map(x => x.type).join(', ')}`,
         `*/`,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,6 +30,7 @@ const plugins = {
     insert,
     merge,
     rename,
+    runSequence,
 };
 
 require('./tasks/gulp-js')(gulp, plugins);

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "scripts": {
     "start": "gulp watch",
     "build": "gulp build",
-    "test": "gulp prod-css && karma start",
+    "test": "gulp build && karma start",
     "devtest": "gulp debug-css && karma start --taucharts-debug",
     "prepublish": "bower install"
   },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/TargetProcess/tauCharts.git"
   },
   "devDependencies": {
+    "@alexlur/rollup-plugin-typescript": "^1.0.4",
     "@types/d3": "^4.9.0",
     "bower": "^1.8.0",
     "chai": "^4.0.2",
@@ -76,7 +77,7 @@
     "run-sequence": "^1.2.2",
     "tau-tooltip": "^1.1.2",
     "ts-loader": "^2.1.0",
-    "typescript": "^2.3.3",
+    "typescript": "^2.4.1",
     "vinyl-source-stream": "^1.1.0",
     "webpack": "^2.6.1"
   },

--- a/src/elements/coords.cartesian.js
+++ b/src/elements/coords.cartesian.js
@@ -9,7 +9,6 @@ import {cartesianAxis, cartesianGrid} from './coords.cartesian.axis';
 import {
     d3_transition as transition,
     d3_selectAllImmediate as selectAllImmediate,
-    d3_decorator_avoidLabelsCollisions
 } from '../utils/d3-decorators';
 var selectOrAppend = utilsDom.selectOrAppend;
 

--- a/tasks/gulp-css.js
+++ b/tasks/gulp-css.js
@@ -22,6 +22,7 @@ module.exports = (gulp, {
     connect,
     insert,
     merge,
+    runSequence,
 }) => {
 
     const getSrc = (name, isPlugin = false) => {
@@ -67,8 +68,15 @@ module.exports = (gulp, {
             .pipe(gulp.dest(destDir));
     };
 
-    const concatThemeStreams = (theme, streams) => {
-        return merge(...streams)
+    const concatTheme = (theme) => {
+
+        const root = getDestDir({production: true, isPlugin: false});
+        const pluginsDir = getDestDir({production: true, isPlugin: true});
+        const sources = [`./${root}/${getDestFile('taucharts', theme)}`]
+            .concat(plugins.map((plugin) => `./${pluginsDir}/${getDestFile(plugin, theme)}`))
+            .concat(`./${root}/${getDestFile('colorbrewer')}`);
+
+        return gulp.src(sources)
             .pipe(concat(`taucharts${getThemePrefix(theme)}.min.css`))
             .pipe(cssmin())
             .pipe(insert.prepend(banner()))
@@ -87,9 +95,7 @@ module.exports = (gulp, {
 
         themes.forEach((theme) => {
 
-            const themeStreams = [];
-
-            themeStreams.push(createStream({
+            streams.push(createStream({
                 name: 'taucharts',
                 theme,
                 isPlugin: false,
@@ -97,23 +103,16 @@ module.exports = (gulp, {
             }));
 
             plugins.forEach((plugin) => {
-                themeStreams.push(createStream({
+                streams.push(createStream({
                     name: plugin,
                     theme,
                     isPlugin: true,
                     production
                 }));
             });
-
-            if (production) {
-                let concatStream = concatThemeStreams(theme, themeStreams.concat(brewerStream));
-                themeStreams.push(concatStream);
-            }
-
-            streams.push(...themeStreams);
         });
 
-        const mergedStream = merge(streams);
+        const mergedStream = merge(...streams);
 
         if (production) {
             return mergedStream;
@@ -123,6 +122,15 @@ module.exports = (gulp, {
             .pipe(connect.reload());
     };
 
-    gulp.task('prod-css', () => buildCSS({production: true}));
+    const minifyCSS = () => {
+        return merge(...themes.map(concatTheme));
+    };
+
+    gulp.task('prod-css_compile', () => buildCSS({production: true}));
+    gulp.task('prod-css_minify', () => minifyCSS());
+    gulp.task('prod-css', (done) => runSequence(
+        'prod-css_compile',
+        'prod-css_minify',
+        done));
     gulp.task('debug-css', () => buildCSS({production: false}));
 };


### PR DESCRIPTION
- Use rollup-plugin-typescript fork until new version release.
- Split compilation and minification into sub-tasks and run sequentially.
- Run full build before tests to see minification errors.
