### PR TITLE
Diff Tooltip improvements

### DIFF
--- a/less/plugins/diff-tooltip.less
+++ b/less/plugins/diff-tooltip.less
@@ -6,13 +6,15 @@
 @interval-highlight_fill: #c4b3e6;
 @interval-highlight_stroke: #b8aecb;
 
+@diff-tooltip_overflow: 15px; // Allows showing updown out of content
+
 .diff-tooltip {
 
     &__table {
         border-top: 1px solid fade(@font-color, 20%);
         margin-top: 5px;
         padding-top: 5px;
-        width: ~"calc(100% + 15px)";
+        width: ~"calc(100% + @{diff-tooltip_overflow})";
     }
 
     &__header {
@@ -21,7 +23,7 @@
         font-weight: 600;
         justify-content: space-between;
         padding: 2px 0px;
-        padding-right: 30px; // padding for updown
+        // padding-right: is set dynamically;
         position: relative;
 
         &__text {
@@ -37,6 +39,7 @@
             display: inline-flex;
             flex: 1 1 auto;
             justify-content: flex-end;
+            margin-right: @diff-tooltip_overflow;
             max-width: 120px;
             padding-left: 10px;
             text-align: right;
@@ -53,7 +56,6 @@
             position: absolute;
             right: 0;
             visibility: hidden; // Hide up/down header
-            width: 28px;
         }
     }
 
@@ -61,7 +63,7 @@
         max-height: 250px;
         overflow: hidden;
         padding: 1px; // Fix to make highlighted border visible
-        padding-right: 30px; // Padding for up/down
+        // padding-right: is set dynamically;
 
         &__content {
             padding-bottom: 1px; // Fix to make last highlighted border visible
@@ -71,6 +73,7 @@
     &__item {
         display: flex;
         justify-content: space-between;
+        margin-right: @diff-tooltip_overflow;
         min-width: 100px;
         position: relative;
 
@@ -114,9 +117,8 @@
             justify-content: flex-start;
             left: 100%;
             height: 100%;
-            padding-left: 4px;
+            padding: 0 4px 0 4px;
             position: absolute;
-            width: 80px;
 
             &_positive {
                 color: @diff-tooltip_positive;

--- a/less/plugins/diff-tooltip.less
+++ b/less/plugins/diff-tooltip.less
@@ -77,6 +77,7 @@
             display: inline-flex;
             height: 100%;
             justify-content: center;
+            min-width: 3px;
             opacity: 0.6;
             position: absolute;
             z-index: 0;

--- a/less/plugins/diff-tooltip.less
+++ b/less/plugins/diff-tooltip.less
@@ -16,17 +16,20 @@
     }
 
     &__header {
+        align-items: stretch;
         display: flex;
         font-weight: 600;
-        padding: 2px 0;
+        justify-content: space-between;
+        padding: 2px 0px;
+        padding-right: 30px; // padding for updown
+        position: relative;
 
         &__text {
             align-items: center;
             display: inline-flex;
             flex: 1 1 auto;
             justify-content: flex-start;
-            text-align: center;
-            width: 60%;
+            max-width: 120px;
         }
 
         &__value {
@@ -34,8 +37,9 @@
             display: inline-flex;
             flex: 1 1 auto;
             justify-content: flex-end;
-            text-align: center;
-            width: 40%;
+            max-width: 120px;
+            padding-left: 10px;
+            text-align: right;
         }
 
         &__updown {
@@ -43,9 +47,11 @@
             display: inline-flex;
             flex: 1 1 auto;
             font-size: 75%;
+            height: 100%;
             justify-content: flex-start;
             padding-left: 2px;
-            text-align: center;
+            position: absolute;
+            right: 0;
             visibility: hidden; // Hide up/down header
             width: 28px;
         }
@@ -64,6 +70,8 @@
 
     &__item {
         display: flex;
+        justify-content: space-between;
+        min-width: 100px;
         position: relative;
 
         &_highlighted {
@@ -84,27 +92,18 @@
         }
 
         &__text {
-            align-items: center;
-            display: inline-flex;
-            flex: 6;
-            justify-content: flex-start;
+            flex: 1 1 auto;
+            overflow: hidden;
             padding: 2px 4px;
-            position: relative;
-            text-align: left;
+            text-overflow: ellipsis;
             white-space: nowrap;
             width: 100%;
             z-index: 1;
         }
 
         &__value {
-            align-items: center;
-            display: inline-flex;
-            flex: 4;
-            justify-content: flex-end;
-            padding: 2px 4px;
-            position: relative;
-            text-align: right;
-            width: 80px;
+            flex: none;
+            padding: 2px 4px 2px 30px;
             z-index: 1;
         }
 

--- a/plugins/diff-tooltip/diff-template.ts
+++ b/plugins/diff-tooltip/diff-template.ts
@@ -141,6 +141,11 @@ export default function DiffTemplate(tooltip: ElementTooltip, settings: TooltipS
         didMount() {
             base.didMount.call(this);
 
+            this._scrollToHighlighted();
+            this._reserveSpaceForUpdown();
+        },
+
+        _scrollToHighlighted() {
             const node = tooltip.getDomNode() as HTMLElement;
             const body = node.querySelector(`.${DIFF_TOOLTIP_CLS}__body`) as HTMLElement;
             const content = node.querySelector(`.${DIFF_TOOLTIP_CLS}__body__content`) as HTMLElement;
@@ -159,11 +164,31 @@ export default function DiffTemplate(tooltip: ElementTooltip, settings: TooltipS
             }
 
             if (h.bottom > b.bottom) {
-                // Scroll to highlighted item
                 const dy = ((h.bottom - b.bottom) + h.height);
                 const limitDy = (c.bottom - b.bottom);
                 content.style.transform = `translateY(${-Math.min(dy, limitDy)}px)`;
             }
+        },
+
+        _reserveSpaceForUpdown() {
+            const node = tooltip.getDomNode() as HTMLElement;
+            const body = node.querySelector(`.${DIFF_TOOLTIP_CLS}__body`) as HTMLElement;
+            const header = node.querySelector(`.${HEADER_CLS}`) as HTMLElement;
+
+            if (!(body && header)) {
+                return;
+            }
+
+            // Todo: Use CSS table layout, no need in JS hack
+            const updownSelector = `.${ROW_CLS}__updown:not(:empty)`;
+            const updowns = Array.from(node.querySelectorAll(updownSelector));
+            const widths = updowns.map((el) => el.getBoundingClientRect().width);
+            const maxWidth = Math.max(...widths);
+            const tooltipPad = 15;
+            const pad = Math.max(0, Math.ceil(maxWidth - tooltipPad));
+
+            body.style.paddingRight = `${pad}px`;
+            header.style.paddingRight = `${pad}px`;
         }
     });
 }

--- a/plugins/diff-tooltip/diff-template.ts
+++ b/plugins/diff-tooltip/diff-template.ts
@@ -106,8 +106,8 @@ export default function DiffTemplate(tooltip: ElementTooltip, settings: TooltipS
             min = Math.min(min, 0);
             max = Math.max(0, max);
             const range = (max - min);
-            const left = ((v < 0 ? v - min : -min) / range);
-            const width = ((v < 0 ? -v : v) / range);
+            const left = (range === 0 ? 0 : ((v < 0 ? v - min : -min) / range));
+            const width = (range === 0 ? 0 : ((v < 0 ? -v : v) / range));
             return [
                 '<span',
                 `    class="${ROW_CLS}__bg${colorCls ? ` ${colorCls}` : ''}"`,

--- a/plugins/diff-tooltip/diff-template.ts
+++ b/plugins/diff-tooltip/diff-template.ts
@@ -47,7 +47,7 @@ export default function DiffTemplate(tooltip: ElementTooltip, settings: TooltipS
         },
 
         tableHeaderTemplate({colorField, valueField}) {
-            const groupLabel = this.getLabel(colorField);
+            const groupLabel = (colorField != null ? this.getLabel(colorField) : 'Group');
             const valueLabel = this.getLabel(valueField);
             return [
                 `<div class="${HEADER_CLS}">`,
@@ -78,7 +78,7 @@ export default function DiffTemplate(tooltip: ElementTooltip, settings: TooltipS
 
         tableRowTemplate({data, prev, highlighted, valueField, colorField, min, max}) {
 
-            const name = this.getLabel(data[colorField]);
+            const name = (colorField != null ? this.getLabel(data[colorField]) : '&mdash;');
             const format = this.getFormatter(valueField);
             const value = format(data[valueField]);
             const isHighlighted = (data === highlighted);

--- a/plugins/diff-tooltip/diff-template.ts
+++ b/plugins/diff-tooltip/diff-template.ts
@@ -78,7 +78,7 @@ export default function DiffTemplate(tooltip: ElementTooltip, settings: TooltipS
 
         tableRowTemplate({data, prev, highlighted, valueField, colorField, min, max}) {
 
-            const name = (colorField != null ? this.getLabel(data[colorField]) : '&mdash;');
+            const name = (colorField != null ? this.getLabel(data[colorField]) : 'no group');
             const format = this.getFormatter(valueField);
             const value = format(data[valueField]);
             const isHighlighted = (data === highlighted);

--- a/plugins/diff-tooltip/diff-template.ts
+++ b/plugins/diff-tooltip/diff-template.ts
@@ -146,6 +146,10 @@ export default function DiffTemplate(tooltip: ElementTooltip, settings: TooltipS
             const content = node.querySelector(`.${DIFF_TOOLTIP_CLS}__body__content`) as HTMLElement;
             const highlighted = node.querySelector(`.${ROW_CLS}_highlighted`) as HTMLElement;
 
+            if (!(body && content && highlighted)) {
+                return;
+            }
+
             const b = body.getBoundingClientRect();
             const c = content.getBoundingClientRect();
             const h = highlighted.getBoundingClientRect();

--- a/plugins/tooltip/fields-template.ts
+++ b/plugins/tooltip/fields-template.ts
@@ -72,15 +72,17 @@ export default function FieldsTemplate(tooltip: ElementTooltip, settings: Toolti
         },
 
         didMount() {
-            tooltip.getDomNode()
-                .querySelector('.i-role-exclude')
-                .addEventListener('click', () => {
+            const excludeBtn = tooltip.getDomNode().querySelector('.i-role-exclude');
+
+            if (excludeBtn) {
+                excludeBtn.addEventListener('click', () => {
                     tooltip.excludeHighlightedElement();
                     tooltip.setState({
                         highlight: null,
                         isStuck: false
                     });
                 });
+            }
         }
     };
 }


### PR DESCRIPTION
- Show default label instead of undefined.
- Min bar width.
- Prevent adding event listeners to missing elements.
- Improved wrapping headers and row text overflow.
- Reserve space for updown (dynamically).
