### PR TITLE
Fix default TypeScript export definition to conform to version 2.6.0 rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "taucharts",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -127,7 +127,7 @@ interface Emitter {
 
 interface PlotSize {
     width?: number;
-    height?: number
+    height?: number;
 }
 
 interface PlotLayout {
@@ -192,7 +192,9 @@ declare var api: {
     };
     tickPeriod: {
         get(name: string, settings?: { utc?: boolean }): { cast: (d: Date) => Date; next: (d: Date) => Date; };
-        add(name: string, period: { cast: (d: Date) => Date; next: (d: Date) => Date; }, settings?: { utc?: boolean }): void;
+        add(name: string,
+            period: { cast: (d: Date) => Date; next: (d: Date) => Date; },
+            settings?: { utc?: boolean }): void;
     };
     globalSettings: ChartSettings;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -301,12 +301,14 @@ declare var api: {
 
 declare var version: string;
 
-export default {
-    Plot,
-    Chart,
-    api,
-    version,
+declare var _default: {
+    Plot: typeof Plot,
+    Chart: typeof Chart,
+    api: typeof api,
+    version: typeof version
 };
+
+export default _default;
 
 export {
     Plot,


### PR DESCRIPTION
## Context

Please see issue here: https://github.com/TargetProcess/tauCharts/issues/519

## Changes made

1. Fix the `package-lock.json` file so that its version number correctly matches that of the `package.json`
2. Do some minor fixes on the `types/index.d.ts` file so that it correctly conforms to the rules outlined in the `tslint.json` file
3. Perform the actual fix on the default export in `types/index.d.ts` to ensure that it is not an arbitrary expression, as this is a breaking change in TypeScript 2.6 - https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#arbitrary-expressions-are-forbidden-in-export-assignments-in-ambient-contexts