### PR TITLE
ci: use npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   - sudo dpkg -i google-chrome*.deb
+install: npm install


### PR DESCRIPTION
Travis CI automatically uses `npm ci` if there is a lockfile but this results in a different set of dependencies.