### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - "lts/*"
+  - "node"
+  - "10"
+  - "8"
+  - "6"
 before_install:
   - export CHROME_BIN=/usr/bin/google-chrome
   - export DISPLAY=:99.0


### PR DESCRIPTION
`lts/*` just tests the latest LTS which is `10` but we currently have 6, 8 and 10 as LTS. See https://github.com/nodejs/Release/blob/master/README.md