### PR TITLE
fix performance for measure dates on very old dates

### DIFF
--- a/src/grammar-registry.ts
+++ b/src/grammar-registry.ts
@@ -496,7 +496,10 @@ GrammarRegistry
         const merge = (templateSorted, fiberSorted, sign) => {
             const groups = utils.groupBy(fiberSorted, (row) => row[dx]);
             const sample = fiberSorted[0];
-            return templateSorted.reduce((memo, k) => memo.concat((groups[k] || (gen(k, sample, sign)))), []);
+            return templateSorted.reduce((memo, k) => {
+                memo.push(...(groups[k] || [gen(k, sample, sign)]));
+                return memo;
+            }, []);
         };
 
         const asc = (a, b) => a - b;


### PR DESCRIPTION
In case dates like from the 1600 year are used, it generates a lot of dates for each day, and performance at that point is very slow